### PR TITLE
Zotero pagination

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov
+        pip install pytest pytest-cov responses
 
     - name: Test with pytest
       run: |

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -2,5 +2,6 @@ pytest==8.3.4
 pytest-cov==6.0.0
 pytest-pretty==1.2.0
 mypy==1.14.1
+responses==0.25.6
 ruff==0.9.1
 types-requests~=2.32.0

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -1,11 +1,38 @@
+import collections.abc
 import os
+import random
+import string
 
 import pytest
+import responses
 
 from mkdocs_bibtex.plugin import BibTexPlugin
 
 module_dir = os.path.dirname(os.path.abspath(__file__))
 test_files_dir = os.path.abspath(os.path.join(module_dir, "..", "test_files"))
+MOCK_ZOTERO_URL = "https://api.zotero.org/groups/FOO/collections/BAR/items?format=bibtex"
+
+@pytest.fixture
+def mock_zotero_api(request: pytest.FixtureRequest) -> collections.abc.Generator[responses.RequestsMock]:
+    zotero_api_url = "https://api.zotero.org/groups/FOO/collections/BAR/items?format=bibtex"
+    bibtex_contents = generate_bibtex_entries(request.param)
+    limit = 25
+    pages = [bibtex_contents[i:i + limit] for i in range(0, len(bibtex_contents), limit)]
+
+    with responses.RequestsMock() as mock_api:
+        for page_num, page in enumerate(pages):
+            current_start = "" if page_num == 0 else f"&start={page_num*limit}"
+            next_start = f"&start={(page_num+1)*limit}"
+            mock_api.add(responses.Response(
+                method="GET",
+                url=f"{zotero_api_url}{current_start}",
+                json="\n".join(page),
+                headers={} if page_num == len(pages)-1 else {
+                    "Link": f"<{zotero_api_url}{next_start}>; rel='next'"
+                }
+            ))
+
+        yield mock_api
 
 
 @pytest.fixture
@@ -106,3 +133,25 @@ def test_footnote_formatting_config(plugin):
 
     with pytest.raises(Exception):
         bad_plugin.on_config(bad_plugin.config)
+
+def generate_bibtex_entries(n: int) -> list[str]:
+    """Generates n random bibtex entries."""
+
+    entries = []
+
+    for i in range(n):
+        author_first = "".join(random.choices(string.ascii_letters, k=8))
+        author_last = "".join(random.choices(string.ascii_letters, k=8))
+        title = "".join(random.choices(string.ascii_letters, k=10))
+        journal = "".join(random.choices(string.ascii_uppercase, k=5))
+        year = str(random.randint(1950, 2025))
+
+        entries.append(f"""
+@article{{{author_last}_{i}}},
+    title = {{{title}}},
+    volume = {{1}},
+    journal = {{{journal}}},
+    author = {{{author_last}, {author_first}}},
+    year = {{{year}}},
+""")
+    return entries

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -75,6 +75,19 @@ def test_bibtex_loading_bibdir():
     assert len(plugin.bib_data.entries) == 2
 
 
+@pytest.mark.parametrize(("mock_zotero_api","number_of_entries"),((4,4), (150,150)), indirect=["mock_zotero_api"])
+def test_bibtex_loading_zotero(mock_zotero_api: responses.RequestsMock, number_of_entries: int) -> None:
+    plugin = BibTexPlugin()
+    plugin.load_config(
+        options={
+            "bib_file": MOCK_ZOTERO_URL
+        },
+        config_file_path=test_files_dir,
+    )
+
+    plugin.on_config(plugin.config)
+    assert len(plugin.bib_data.entries) == number_of_entries
+
 def test_on_page_markdown(plugin):
     """
     This function just tests to make sure the rendered markdown changees with

--- a/test_files/test_plugin.py
+++ b/test_files/test_plugin.py
@@ -15,9 +15,10 @@ MOCK_ZOTERO_URL = "https://api.zotero.org/groups/FOO/collections/BAR/items?forma
 
 @pytest.fixture
 def mock_zotero_api(request: pytest.FixtureRequest) -> collections.abc.Generator[responses.RequestsMock]:
-    zotero_api_url = "https://api.zotero.org/groups/FOO/collections/BAR/items?format=bibtex"
+    zotero_api_url = "https://api.zotero.org/groups/FOO/collections/BAR/items?format=bibtex&limit=100"
     bibtex_contents = generate_bibtex_entries(request.param)
-    limit = 25
+
+    limit = 100
     pages = [bibtex_contents[i : i + limit] for i in range(0, len(bibtex_contents), limit)]
 
     with responses.RequestsMock() as mock_api:

--- a/test_files/test_utils.py
+++ b/test_files/test_utils.py
@@ -7,6 +7,7 @@ from mkdocs_bibtex.utils import (
     format_simple,
     format_pandoc,
     extract_cite_keys,
+    sanitize_zotero_query,
 )
 
 from mkdocs_bibtex.plugin import parse_file
@@ -75,3 +76,32 @@ def test_extract_cite_key():
     """
     assert extract_cite_keys("[@test]") == ["test"]
     assert extract_cite_keys("[@test.3]") == ["test.3"]
+
+
+EXAMPLE_ZOTERO_API_ENDPOINT = "https://api.zotero.org/groups/FOO/collections/BAR/items"
+
+
+@pytest.mark.parametrize(
+    ("zotero_url", "expected_sanitized_url"),
+    (
+        (f"{EXAMPLE_ZOTERO_API_ENDPOINT}", f"{EXAMPLE_ZOTERO_API_ENDPOINT}?format=bibtex&limit=100"),
+        (
+            f"{EXAMPLE_ZOTERO_API_ENDPOINT}?format=bibtex&limit=25",
+            f"{EXAMPLE_ZOTERO_API_ENDPOINT}?format=bibtex&limit=100",
+        ),
+        (
+            f"{EXAMPLE_ZOTERO_API_ENDPOINT}?format=json",
+            f"{EXAMPLE_ZOTERO_API_ENDPOINT}?format=bibtex&limit=100",
+        ),
+        (
+            f"{EXAMPLE_ZOTERO_API_ENDPOINT}?sort=dateAdded",
+            f"{EXAMPLE_ZOTERO_API_ENDPOINT}?sort=dateAdded&format=bibtex&limit=100",
+        ),
+        (
+            f"{EXAMPLE_ZOTERO_API_ENDPOINT}?sort=dateAdded&sort=publisher",
+            f"{EXAMPLE_ZOTERO_API_ENDPOINT}?sort=publisher&format=bibtex&limit=100",
+        ),
+    ),
+)
+def test_sanitize_zotero_query(zotero_url: str, expected_sanitized_url: str) -> None:
+    assert sanitize_zotero_query(url=zotero_url) == expected_sanitized_url


### PR DESCRIPTION
@brocksam do you want to have a quick look before I propose this PR to the origin repo?

This PR addresses #287.

After considering https://github.com/shyamd/mkdocs-bibtex/issues/287#issuecomment-2593518339, I made the following design decisions:

1. I wanted to keep the external API in `plugin.py` unchanged so that meant making changes through the `tempfile_from_url()` function. However, because I needed to wrap the request logic into a for loop _and_ delay the tempfile writing until after the loop, I elected to delegate the zotero-specific logic to a `tempfile_from_zotero()`.
2. I have chosen to omit the #171 feature request to limit the scope of this PR to pagination only
3. To prevent an excessive number of requests/pagination iterations, I have limited the for-loop to 999 requests rather arbitrarily. Do you have a view on what this number should be or if there is a better way to limit the iterations?
4. Instead of using a live zotero endpoint, I have decided to mock the API endpoint with the [`responses`](https://github.com/getsentry/responses) package. It is fairly popular (4.2k stars) and definitely more popular than some of the options I considered like [`httmock`](https://github.com/patrys/httmock) and [`request-mock`](https://github.com/jamielennox/requests-mock). By mocking the API endpoint, I can ensure consistent behaviour by eliminating problems with inconsistent internet connection etc. I've tried my best to replicate the API endpoint according to the Zotero [docs](https://www.zotero.org/support/dev/web_api/v3/basics) with the minimum data required for pagination behaviour.
5. In mocking the API, I have created a `generate_bibtex_entries()` function in `test_files/test_plugin.py` as it is only used in the `mock_zotero_api` fixture and hence does not need to be part of the build directory. If there was a conftest.py file, I think it would be better placed there. If this location is unsuitable for you, please let me know where you think I should move it to.
6. I've included type annotations but I noticed that the rest of the codebase does not. If you would like me to remove the annotations to fit better with the style in this repository, please let me know.